### PR TITLE
make rocksdb the default engine

### DIFF
--- a/debian.community/postinst
+++ b/debian.community/postinst
@@ -89,7 +89,7 @@ if [ "$RET" = "true" ];  then
         echo "Database files are up-to-date."
     fi
 elif [ "$UPGRADE" = "true" ];  then
-    echo "Warning: database files need upgrade, automatic upgrade is disable, please do it manually."
+    echo "Warning: database files need upgrade, automatic upgrade is disabled, please do it manually."
     echo "After you've prepared your system for upgrade run "
     echo "  /usr/share/arangodb3/arangodb-update-db"
     echo "  dpkg --pending --configure"

--- a/debian.community/templates
+++ b/debian.community/templates
@@ -41,5 +41,5 @@ Description: Database storage engine
  Please note that you can't switch storage engines of existing installations,
  a dump and restore is required therefore.
  
- 'auto' will pick the existing one or default to mmfiles.
+ 'auto' will pick the existing one or default to rocksdb.
 

--- a/debian.enterprise/postinst
+++ b/debian.enterprise/postinst
@@ -89,7 +89,7 @@ if [ "$RET" = "true" ];  then
         echo "Database files are up-to-date."
     fi
 elif [ "$UPGRADE" = "true" ];  then
-    echo "Warning: database files need upgrade, automatic upgrade is disable, please do it manually."
+    echo "Warning: database files need upgrade, automatic upgrade is disabled, please do it manually."
     echo "After you've prepared your system for upgrade run "
     echo "  /usr/share/arangodb3/arangodb-update-db"
     echo "  dpkg --pending --configure"

--- a/debian.enterprise/templates
+++ b/debian.enterprise/templates
@@ -41,5 +41,5 @@ Description: Database storage engine
  Please note that you can't switch storage engines of existing installations,
  a dump and restore is required therefore.
  
- 'auto' will pick the existing one or default to mmfiles.
+ 'auto' will pick the existing one or default to rocksdb.
 


### PR DESCRIPTION
Question: will this affect other versions than devel, or just devel?
In case it affects other versions too, we need to adjust this PR again!