### PR TITLE
Enforce LF line endings for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
By default, Git checks out files with CRLF line endings on Windows, which breaks shell scripts