### PR TITLE
do not move away "old" JS directories

### DIFF
--- a/debian.community/preinst
+++ b/debian.community/preinst
@@ -13,11 +13,3 @@ getent passwd arangodb >/dev/null || useradd -r -g arangodb -d /usr/share/arango
 install -o arangodb -g arangodb -m 755 -d /var/lib/arangodb3
 install -o arangodb -g arangodb -m 755 -d /var/lib/arangodb3-apps
 install -o arangodb -g arangodb -m 755 -d /var/log/arangodb3
-
-rm -rf /usr/share/arangodb3/js.old
-
-if test -d /usr/share/arangodb3/js; then
-  mv /usr/share/arangodb3/js /usr/share/arangodb3/js.old
-fi
-
-

--- a/debian.enterprise/preinst
+++ b/debian.enterprise/preinst
@@ -13,11 +13,3 @@ getent passwd arangodb >/dev/null || useradd -r -g arangodb -d /usr/share/arango
 install -o arangodb -g arangodb -m 755 -d /var/lib/arangodb3
 install -o arangodb -g arangodb -m 755 -d /var/lib/arangodb3-apps
 install -o arangodb -g arangodb -m 755 -d /var/log/arangodb3
-
-rm -rf /usr/share/arangodb3/js.old
-
-if test -d /usr/share/arangodb3/js; then
-  mv /usr/share/arangodb3/js /usr/share/arangodb3/js.old
-fi
-
-


### PR DESCRIPTION
do not move away old JS directories on installation, as we now have a versioned JS directory