### PR TITLE
probe nscd for rpm installs too

### DIFF
--- a/rpm/arangodb3.spec.in
+++ b/rpm/arangodb3.spec.in
@@ -227,6 +227,16 @@ if ! getent passwd arangodb >/dev/null 2>&1; then
         /usr/sbin/usermod -c "Arango Server" arangodb
 fi
 
+# check if the arangodb group was added locally in /etc/group
+# if not, then the arangod binary will very likely try to open a socket
+# connection to nscd to query the group information from there.
+# if there is no nscd running, starting the arangod binary will fail
+if ! grep "^arangodb:" /etc/group >/dev/null; then
+  if ! nscd -g >/dev/null 2>&1; then
+    echo "Unable to query nscd service for user 'arangodb'. As a consequence, it is very likely that starting the arangod server will fail because it can neither find user 'arangodb' in /etc/group nor via an nscd group lookup."
+  fi
+fi
+
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                             preun
 ## -----------------------------------------------------------------------------

--- a/rpm/arangodb3e.spec.in
+++ b/rpm/arangodb3e.spec.in
@@ -227,6 +227,16 @@ if ! getent passwd arangodb >/dev/null 2>&1; then
         /usr/sbin/usermod -c "Arango Server" arangodb
 fi
 
+# check if the arangodb group was added locally in /etc/group
+# if not, then the arangod binary will very likely try to open a socket
+# connection to nscd to query the group information from there.
+# if there is no nscd running, starting the arangod binary will fail
+if ! grep "^arangodb:" /etc/group >/dev/null; then
+  if ! nscd -g >/dev/null 2>&1; then
+    echo "Unable to query nscd service for user 'arangodb'. As a consequence, it is very likely that starting the arangod server will fail because it can neither find user 'arangodb' in /etc/group nor via an nscd group lookup."
+  fi
+fi
+
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                             preun
 ## -----------------------------------------------------------------------------


### PR DESCRIPTION
We do this for debian packages already. Was missing for the rpms.
This is *untested*.