### PR TITLE
Port change to generateMdFiles.py from main repo (links to option sub-chapters)

### DIFF
--- a/containers/documentation.docker/generateMdFiles.py
+++ b/containers/documentation.docker/generateMdFiles.py
@@ -957,7 +957,9 @@ def loadProgramOptionBlocks(blocks):
 
             # Output table header with column labels (one table per section)
             output.append('\n<h2>{} Options</h2>'.format(groupName.title()))
-            output.append('<table class="program-options"><thead><tr>')
+            if program in ['arangod']:
+                output.append('\nAlso see <a href="{0}.html">{0} details</a>.'.format(groupName.title()))
+            output.append('\n<table class="program-options"><thead><tr>')
             output.append('<th>{}</th><th>{}</th><th>{}</th>'.format('Name', 'Type', 'Description'))
             output.append('</tr></thead><tbody>')
 


### PR DESCRIPTION
Auto-generate links above option tables to sub-chapters (port of 9daa52b)